### PR TITLE
Fix styles in shadow DOM

### DIFF
--- a/themes/cybertopia-cherry.css
+++ b/themes/cybertopia-cherry.css
@@ -4,7 +4,7 @@
   Repository: https://github.com/noraj/cybertopia-highlightjs
 */
 
-:root {
+:root, :host {
   --hljs-bg: #101010;
   --hljs-mono-1: #abb2bf;
   --hljs-mono-3: #5c6370;

--- a/themes/cybertopia-dimmer.css
+++ b/themes/cybertopia-dimmer.css
@@ -4,7 +4,7 @@
   Repository: https://github.com/noraj/cybertopia-highlightjs
 */
 
-:root {
+:root, :host {
   --hljs-bg: #101010;
   --hljs-mono-1: #abb2bf;
   --hljs-mono-3: #5c6370;

--- a/themes/cybertopia-icecap.css
+++ b/themes/cybertopia-icecap.css
@@ -4,7 +4,7 @@
   Repository: https://github.com/noraj/cybertopia-highlightjs
 */
 
-:root {
+:root, :host {
   --hljs-bg: #101010;
   --hljs-mono-1: #abb2bf;
   --hljs-mono-3: #5c6370;

--- a/themes/cybertopia-saturated.css
+++ b/themes/cybertopia-saturated.css
@@ -4,7 +4,7 @@
   Repository: https://github.com/noraj/cybertopia-highlightjs
 */
 
-:root {
+:root, :host {
   --hljs-bg: #101010;
   --hljs-mono-1: #abb2bf;
   --hljs-mono-3: #5c6370;


### PR DESCRIPTION
Hi noraj.

I found that the themes do not render correctly when inside shadow DOM because the `:root` selector does not match. This PR adds the `:host` selector to fix this.

I have already opened a PR in the highlight.js repo https://github.com/highlightjs/highlight.js/pull/4277

Cheers